### PR TITLE
feat: agenda do nutricionista com confirmação, remarcação e lembretes

### DIFF
--- a/frontend/dashboard-nutricionista.html
+++ b/frontend/dashboard-nutricionista.html
@@ -91,6 +91,10 @@
               <h2 class="text-lg font-bold">Agenda</h2>
               <button id="btnOpenAppointment" class="text-xs bg-nutriflow-200 px-3 py-1 rounded-md font-bold">Agendar</button>
             </div>
+            <div class="mb-3 rounded-xl border border-amber-200 bg-amber-50/70 p-3">
+              <p class="text-[11px] font-bold uppercase tracking-[0.14em] text-amber-700">Lembretes</p>
+              <div id="appointmentRemindersList" class="mt-2 space-y-2"></div>
+            </div>
             <div id="appointmentsList" class="space-y-3"></div>
           </article>
         </section>

--- a/frontend/dashboard-nutricionista.js
+++ b/frontend/dashboard-nutricionista.js
@@ -23,7 +23,14 @@ const state = {
   selectedPatientId: null,
   activeFilterId: null, // Novo: Guarda se estamos filtrando a tela por um paciente
   activeChallengeId: null, // Para adicionar pacientes a desafios
-  mealPlans: [], assessments: [], appointments: [], challenges: [], messages: [], foods: []
+  mealPlans: [], assessments: [], appointments: [], challenges: [], messages: [], foods: [], reminders: []
+};
+
+const APPOINTMENT_STATUS_LABELS = {
+  agendada: 'Agendada',
+  confirmada: 'Confirmada',
+  remarcada: 'Remarcada',
+  faltou: 'Faltou',
 };
 
 const toast = document.getElementById('nutritionistToast');
@@ -39,6 +46,7 @@ async function fetchDatabaseData() {
     state.mealPlans = data.mealPlans || [];
     state.assessments = data.assessments || [];
     state.appointments = data.appointments || [];
+    state.reminders = data.reminders || [];
     state.challenges = data.challenges || [];
     state.messages = data.messages || [];
     state.foods = data.foods || [];
@@ -311,14 +319,32 @@ function renderGeneralLists() {
     `).join('') : '<p class="text-sm text-nutriflow-500">Nenhuma avaliação.</p>';
 
   const agendaContainer = document.getElementById('appointmentsList');
+  const remindersContainer = document.getElementById('appointmentRemindersList');
+
+  if (remindersContainer) {
+    remindersContainer.innerHTML = state.reminders.length
+      ? state.reminders.map((reminder) => `
+        <div class="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2">
+          <p class="text-xs font-bold uppercase tracking-[0.12em] text-amber-700">${escapeHtml(reminder.reminder?.label || 'Lembrete')}</p>
+          <p class="mt-1 text-sm font-bold text-nutriflow-950">${escapeHtml(reminder.patient)} - ${escapeHtml(reminder.type)}</p>
+          <p class="text-xs text-nutriflow-700">${escapeHtml(reminder.date)} (${escapeHtml(String(reminder.reminder?.minutesUntil || 0))} min)</p>
+        </div>
+      `).join('')
+      : '<p class="text-sm text-nutriflow-500">Sem lembretes de consulta nas próximas 24h.</p>';
+  }
+
   agendaContainer.innerHTML = apps.length ? apps.map(app => `
       <div class="bg-white border rounded-xl p-3 shadow-sm flex justify-between items-center relative group">
         <div>
           <p class="text-sm font-bold text-nutriflow-950">${app.patient}</p>
           <p class="text-xs font-bold text-nutriflow-500">${app.type}</p>
+          <p class="text-[11px] font-bold text-nutriflow-700 mt-1">Status: ${escapeHtml(APPOINTMENT_STATUS_LABELS[app.status] || app.status)}</p>
         </div>
         <div class="flex items-center gap-2">
           <p class="text-xs font-bold bg-nutriflow-50 px-2 py-1 rounded-lg">${app.date}</p>
+          <button onclick="window.updateAppointmentStatus('${app.id}', 'confirmada')" class="rounded-lg border border-emerald-200 bg-emerald-50 px-2 py-1 text-[11px] font-bold text-emerald-700">Confirmar</button>
+          <button onclick="window.rescheduleAppointment('${app.id}')" class="rounded-lg border border-amber-200 bg-amber-50 px-2 py-1 text-[11px] font-bold text-amber-700">Remarcar</button>
+          <button onclick="window.updateAppointmentStatus('${app.id}', 'faltou')" class="rounded-lg border border-rose-200 bg-rose-50 px-2 py-1 text-[11px] font-bold text-rose-700">Faltou</button>
           <button onclick="window.deleteResource('appointments', '${app.id}')" class="text-red-400 hover:text-red-600 opacity-0 group-hover:opacity-100 transition">🗑️</button>
         </div>
       </div>
@@ -375,6 +401,38 @@ window.duplicatePlan = function(planId) {
 window.openAddParticipant = function(challengeId) {
   state.activeChallengeId = challengeId;
   openModal('addParticipant');
+};
+
+window.updateAppointmentStatus = async function(appointmentId, status) {
+  try {
+    await apiRequest(`/api/nutritionist/appointments/${appointmentId}/status`, {
+      method: 'PATCH',
+      body: JSON.stringify({ status }),
+    });
+    showToast('Status da consulta atualizado.');
+    await fetchDatabaseData();
+  } catch (error) {
+    showToast(error.message || 'Erro ao atualizar status da consulta.');
+  }
+};
+
+window.rescheduleAppointment = async function(appointmentId) {
+  const newDate = window.prompt('Nova data/hora (formato: 2026-12-30T14:30):');
+
+  if (!newDate) {
+    return;
+  }
+
+  try {
+    await apiRequest(`/api/nutritionist/appointments/${appointmentId}/reschedule`, {
+      method: 'PATCH',
+      body: JSON.stringify({ scheduledAt: newDate }),
+    });
+    showToast('Consulta remarcada com sucesso.');
+    await fetchDatabaseData();
+  } catch (error) {
+    showToast(error.message || 'Erro ao remarcar consulta.');
+  }
 };
 
 // MODAIS

--- a/src/controllers/nutritionistDashboardController.js
+++ b/src/controllers/nutritionistDashboardController.js
@@ -35,6 +35,26 @@ class NutritionistDashboardController {
     response.status(201).json(result);
   }
 
+  async updateAppointmentStatus(request, response) {
+    const nutritionist = await this.sessionService.requireNutritionist(request);
+    const result = await this.nutritionistDashboardService.updateAppointmentStatus(
+      nutritionist,
+      request.params.id,
+      request.body || {},
+    );
+    response.status(200).json(result);
+  }
+
+  async rescheduleAppointment(request, response) {
+    const nutritionist = await this.sessionService.requireNutritionist(request);
+    const result = await this.nutritionistDashboardService.rescheduleAppointment(
+      nutritionist,
+      request.params.id,
+      request.body || {},
+    );
+    response.status(200).json(result);
+  }
+
   // Nova Função: Adicionar ao Desafio
   async addChallengeParticipant(request, response) {
     const nutritionist = await this.sessionService.requireNutritionist(request);

--- a/src/repositories/nutritionistDashboardRepository.js
+++ b/src/repositories/nutritionistDashboardRepository.js
@@ -788,6 +788,38 @@ class NutritionistDashboardRepository {
         type: data.type,
         status: data.status,
       },
+      include: {
+        patientProfile: {
+          include: {
+            user: true,
+          },
+        },
+      },
+    });
+  }
+
+  async updateAppointment(nutritionistId, appointmentId, data) {
+    const appointment = await this.prisma.appointment.findFirst({
+      where: {
+        id: appointmentId,
+        nutritionistId,
+      },
+    });
+
+    if (!appointment) {
+      return null;
+    }
+
+    return this.prisma.appointment.update({
+      where: { id: appointmentId },
+      data,
+      include: {
+        patientProfile: {
+          include: {
+            user: true,
+          },
+        },
+      },
     });
   }
 

--- a/src/routes/nutritionistRoutes.js
+++ b/src/routes/nutritionistRoutes.js
@@ -11,6 +11,8 @@ function createNutritionistRoutes(nutritionistDashboardController) {
   router.post('/assessments', asyncHandler(nutritionistDashboardController.createAssessment.bind(nutritionistDashboardController)));
   router.post('/challenges', asyncHandler(nutritionistDashboardController.createChallenge.bind(nutritionistDashboardController)));
   router.post('/appointments', asyncHandler(nutritionistDashboardController.createAppointment.bind(nutritionistDashboardController))); // Nova Rota
+  router.patch('/appointments/:id/status', asyncHandler(nutritionistDashboardController.updateAppointmentStatus.bind(nutritionistDashboardController)));
+  router.patch('/appointments/:id/reschedule', asyncHandler(nutritionistDashboardController.rescheduleAppointment.bind(nutritionistDashboardController)));
   
   router.post('/link-patient', asyncHandler(nutritionistDashboardController.linkPatient.bind(nutritionistDashboardController)));
   router.post('/messages', asyncHandler(nutritionistDashboardController.sendMessage.bind(nutritionistDashboardController)));

--- a/src/services/nutritionistDashboardService.js
+++ b/src/services/nutritionistDashboardService.js
@@ -85,6 +85,59 @@ function toNumber(value, fallback = 0) {
   return Number.isFinite(parsed) ? parsed : fallback;
 }
 
+const APPOINTMENT_STATUSES = {
+  SCHEDULED: 'agendada',
+  CONFIRMED: 'confirmada',
+  RESCHEDULED: 'remarcada',
+  MISSED: 'faltou',
+};
+
+const ALLOWED_APPOINTMENT_STATUSES = new Set(Object.values(APPOINTMENT_STATUSES));
+
+function normalizeAppointmentStatus(value) {
+  const normalized = normalizeText(value).toLowerCase();
+
+  if (!normalized) {
+    return APPOINTMENT_STATUSES.SCHEDULED;
+  }
+
+  if (normalized === 'confirmado' || normalized === 'confirmada') {
+    return APPOINTMENT_STATUSES.CONFIRMED;
+  }
+
+  if (normalized === 'a confirmar' || normalized === 'pendente') {
+    return APPOINTMENT_STATUSES.SCHEDULED;
+  }
+
+  if (ALLOWED_APPOINTMENT_STATUSES.has(normalized)) {
+    return normalized;
+  }
+
+  throw new AppError('Status de consulta invalido. Use: agendada, confirmada, remarcada ou faltou.', 400);
+}
+
+function buildAppointmentReminder(appointment) {
+  const scheduledAt = new Date(appointment.scheduledAt);
+
+  if (Number.isNaN(scheduledAt.getTime())) {
+    return null;
+  }
+
+  const diffMs = scheduledAt.getTime() - Date.now();
+
+  if (diffMs < 0 || diffMs > 24 * 60 * 60 * 1000) {
+    return null;
+  }
+
+  return {
+    due: true,
+    minutesUntil: Math.max(0, Math.round(diffMs / 60000)),
+    label: diffMs <= 60 * 60 * 1000
+      ? 'Consulta em menos de 1 hora'
+      : 'Consulta nas proximas 24 horas',
+  };
+}
+
 function calculateAverage(numbers) {
   if (!numbers.length) {
     return 0;
@@ -486,10 +539,71 @@ class NutritionistDashboardService {
       patientProfileId,
       scheduledAt,
       type,
-      status: 'Confirmado',
+      status: APPOINTMENT_STATUSES.SCHEDULED,
     });
 
-    return { message: 'Consulta agendada com sucesso.', appointment };
+    return {
+      message: 'Consulta agendada com sucesso.',
+      appointment: this.toAppointmentDto({
+        ...appointment,
+        patientProfile: {
+          user: {
+            name: patient.user.name,
+          },
+        },
+      }),
+    };
+  }
+
+  async updateAppointmentStatus(nutritionist, appointmentId, payload) {
+    const normalizedAppointmentId = String(appointmentId || '').trim();
+    const status = normalizeAppointmentStatus(payload.status);
+
+    if (!normalizedAppointmentId) {
+      throw new AppError('Informe a consulta para atualizar o status.', 400);
+    }
+
+    const appointment = await this.nutritionistDashboardRepository.updateAppointment(
+      nutritionist.id,
+      normalizedAppointmentId,
+      { status },
+    );
+
+    if (!appointment) {
+      throw new AppError('Consulta nao encontrada para este nutricionista.', 404);
+    }
+
+    return {
+      message: 'Status da consulta atualizado com sucesso.',
+      appointment: this.toAppointmentDto(appointment),
+    };
+  }
+
+  async rescheduleAppointment(nutritionist, appointmentId, payload) {
+    const normalizedAppointmentId = String(appointmentId || '').trim();
+    const scheduledAt = this.parseDate(payload.date || payload.scheduledAt, 'Informe uma nova data valida.');
+
+    if (!normalizedAppointmentId) {
+      throw new AppError('Informe a consulta para remarcar.', 400);
+    }
+
+    const appointment = await this.nutritionistDashboardRepository.updateAppointment(
+      nutritionist.id,
+      normalizedAppointmentId,
+      {
+        scheduledAt,
+        status: APPOINTMENT_STATUSES.RESCHEDULED,
+      },
+    );
+
+    if (!appointment) {
+      throw new AppError('Consulta nao encontrada para este nutricionista.', 404);
+    }
+
+    return {
+      message: 'Consulta remarcada com sucesso.',
+      appointment: this.toAppointmentDto(appointment),
+    };
   }
 
   async deleteResource(nutritionist, resourceType, id) {
@@ -550,6 +664,10 @@ class NutritionistDashboardService {
     const assessments = workspace.assessments.map((assessment) => this.toAssessmentDto(assessment));
     const messages = patientMessages.map((message) => this.toMessageDto(message));
     const appointments = workspace.appointments.map((appointment) => this.toAppointmentDto(appointment));
+    const reminders = appointments
+      .filter((appointment) => appointment.reminder?.due)
+      .sort((left, right) => left.reminder.minutesUntil - right.reminder.minutesUntil)
+      .slice(0, 5);
     const challenges = workspace.challenges.map((challenge) => this.toChallengeDto(challenge));
 
     return {
@@ -564,12 +682,14 @@ class NutritionistDashboardService {
         activePlans: mealPlans.filter((plan) => plan.status === 'Ativo').length,
         monthlyAssessments: this.countCurrentMonthAssessments(workspace.assessments),
         pendingMessages: patientMessages.filter((message) => message.pending).length,
+        pendingAppointments: appointments.filter((appointment) => appointment.status !== APPOINTMENT_STATUSES.MISSED).length,
       },
       patients,
       mealPlans,
       assessments,
       messages,
       appointments,
+      reminders,
       challenges,
       foods: foods.map((food) => this.toFoodDto(food)),
       reports: this.buildReports(patients, mealPlans, workspace.assessments),
@@ -736,13 +856,17 @@ class NutritionistDashboardService {
   }
 
   toAppointmentDto(appointment) {
+    const normalizedStatus = normalizeAppointmentStatus(appointment.status);
+    const reminder = buildAppointmentReminder(appointment);
+
     return {
       id: appointment.id,
       patientId: appointment.patientProfileId,
       patient: appointment.patientProfile.user.name,
       date: formatDateTime(appointment.scheduledAt),
       type: appointment.type,
-      status: appointment.status,
+      status: normalizedStatus,
+      reminder,
     };
   }
 


### PR DESCRIPTION
Este PR adiciona melhorias na agenda do nutricionista para facilitar o acompanhamento das consultas.

O que foi implementado:

Status de consulta:

agendada

confirmada

remarcada

faltou

Novas ações na agenda:

Confirmar consulta

Remarcar consulta

Marcar falta

Lembretes automáticos:

Exibição de consultas nas próximas 24 horas

Destaque visual no painel de agenda

Backend:

Novos endpoints para atualizar status e remarcar consultas

Ajustes de service/controller/repository para suportar o novo fluxo

Frontend:

Atualização da tela de agenda com status e botões de ação

Bloco de lembretes integrado no dashboard do nutricionista

Impacto esperado:

Melhor controle da rotina clínica
Menos perda de consultas
Fluxo mais claro para gestão da agenda
Validação:
