### PR TITLE
Adiciona medidas corporais e corrige chat do nutricionista

### DIFF
--- a/frontend/dashboard-nutricionista.html
+++ b/frontend/dashboard-nutricionista.html
@@ -68,9 +68,10 @@
             </div>
             <div class="rounded-xl bg-nutriflow-950 p-4 text-white">
               <p id="selectedPatientName" class="text-xl font-bold">Nenhum selecionado</p>
-              <div class="mt-4 flex gap-4 text-sm font-bold">
+              <div class="mt-4 flex flex-wrap gap-4 text-sm font-bold">
                 <div><span class="text-white/60 block text-xs">Peso</span><span id="selectedPatientWeight">--</span></div>
                 <div><span class="text-white/60 block text-xs">Altura</span><span id="selectedPatientHeight">--</span></div>
+                <div><span class="text-white/60 block text-xs">Gordura</span><span id="selectedPatientBodyFat">--</span></div>
               </div>
             </div>
             <button id="selectedPatientViewButton" class="mt-4 w-full rounded-lg border border-nutriflow-300 bg-white px-4 py-2 text-sm font-bold text-nutriflow-950 transition hover:bg-nutriflow-50">Ver Perfil Completo</button>
@@ -152,7 +153,15 @@
         <div>
           <div class="grid gap-4 mb-4">
             <div class="bg-nutriflow-50 border border-nutriflow-200 rounded-xl p-4"><p class="text-xs font-bold uppercase text-nutriflow-600 mb-1">Plano Atual</p><p id="patientProfilePlanTitle" class="text-lg font-bold text-nutriflow-950">--</p></div>
-            <div class="bg-nutriflow-50 border border-nutriflow-200 rounded-xl p-4"><p class="text-xs font-bold uppercase text-nutriflow-600 mb-1">Histórico de Peso (Clínico)</p><div id="patientProfileWeightHistory" class="flex flex-wrap gap-2 mt-1"></div></div>
+            <div class="bg-nutriflow-50 border border-nutriflow-200 rounded-xl p-4"><p class="text-xs font-bold uppercase text-nutriflow-600 mb-1">Historico de Peso (Clinico)</p><div id="patientProfileWeightHistory" class="flex flex-wrap gap-2 mt-1"></div></div>
+            <div class="bg-white border border-nutriflow-200 rounded-xl p-4">
+              <p class="text-xs font-bold uppercase text-nutriflow-600 mb-1">Medidas Corporais Recentes</p>
+              <div id="patientProfileBodyMeasurements" class="mt-3 grid gap-2 sm:grid-cols-2"></div>
+            </div>
+            <div class="bg-white border border-nutriflow-200 rounded-xl p-4">
+              <p class="text-xs font-bold uppercase text-nutriflow-600 mb-1">Historico de Medidas</p>
+              <div id="patientProfileBodyMeasurementHistory" class="mt-3 space-y-3"></div>
+            </div>
           </div>
           <div class="flex gap-2">
             <button id="btnProfileNewPlan" class="bg-nutriflow-950 text-white text-sm font-bold px-4 py-2 rounded-lg flex-1">Criar Plano</button>
@@ -202,11 +211,25 @@
     <div class="nf-modal-card !max-w-xl">
       <div class="flex justify-between gap-4"><div><h3 class="text-xl font-bold">Registrar Avaliação Física</h3></div><button class="nf-modal-close" data-close="assessment">x</button></div>
       <form id="assessmentForm" class="mt-4 grid gap-3">
-        <label class="nf-field"><span>Paciente</span><select id="assessmentPatient" class="font-bold"></select></label>
+        <div class="grid gap-3 md:grid-cols-2">
+          <label class="nf-field"><span>Paciente</span><select id="assessmentPatient" class="font-bold"></select></label>
+          <label class="nf-field"><span>Data da Avaliacao</span><input id="assessmentDate" type="date" class="font-bold" required /></label>
+        </div>
         <div class="grid grid-cols-3 gap-3">
           <label class="nf-field"><span>Peso (kg)</span><input id="assessmentWeight" type="number" step="0.1" class="font-bold" required /></label>
           <label class="nf-field"><span>Altura (m)</span><input id="assessmentHeight" type="number" step="0.01" class="font-bold" required/></label>
           <label class="nf-field"><span>% Gordura</span><input id="assessmentBodyFat" type="number" step="0.1" class="font-bold" required/></label>
+        </div>
+        <label class="nf-field"><span>Observacoes</span><textarea id="assessmentNotes" rows="2" class="font-bold" placeholder="Ex: cintura reduziu, adesao boa e composicao corporal evoluindo."></textarea></label>
+        <div class="rounded-xl border border-nutriflow-200 bg-nutriflow-50 p-3">
+          <div class="flex flex-wrap items-center justify-between gap-2">
+            <div>
+              <p class="text-xs font-bold uppercase tracking-[0.16em] text-nutriflow-600">Medidas Complementares</p>
+              <p class="text-xs text-nutriflow-600">Adicione cintura, quadril, abdome, braco ou outras medidas clinicas.</p>
+            </div>
+            <button id="btnAddAssessmentMeasurement" class="rounded-lg bg-white px-3 py-2 text-xs font-bold text-nutriflow-950 shadow-sm" type="button">Adicionar Medida</button>
+          </div>
+          <div id="assessmentMeasurementsList" class="mt-3 grid gap-2"></div>
         </div>
         <div class="flex justify-end gap-2 mt-2">
           <button class="rounded-lg border px-4 py-2 text-sm font-bold" type="button" data-close="assessment">Cancelar</button>

--- a/frontend/dashboard-nutricionista.js
+++ b/frontend/dashboard-nutricionista.js
@@ -23,7 +23,12 @@ const state = {
   selectedPatientId: null,
   activeFilterId: null, // Novo: Guarda se estamos filtrando a tela por um paciente
   activeChallengeId: null, // Para adicionar pacientes a desafios
-  mealPlans: [], assessments: [], appointments: [], challenges: [], messages: [], foods: [], reminders: []
+  mealPlans: [], assessments: [], appointments: [], challenges: [], messages: [], foods: [], reminders: [],
+  chatPatientId: null,
+  activeConversation: null,
+  lastConversationSignature: '',
+  isSendingChatMessage: false,
+  isLoadingConversation: false,
 };
 
 const APPOINTMENT_STATUS_LABELS = {
@@ -35,8 +40,115 @@ const APPOINTMENT_STATUS_LABELS = {
 
 const toast = document.getElementById('nutritionistToast');
 const toastController = createToastController(toast, { duration: 3000 });
+const chatModal = document.getElementById('floatingChat');
+const chatMessages = document.getElementById('chatMessages');
+const chatForm = document.getElementById('chatForm');
+const chatInput = document.getElementById('chatInput');
+const chatSubmitButton = document.getElementById('chatSubmitBtn');
+const chatPatientSelect = document.getElementById('chatPatientSelect');
+let nutritionistChatSyncIntervalId = null;
+let nutritionistChatSyncInFlight = false;
+
+if (chatInput) {
+  chatInput.maxLength = 500;
+}
+
 function showToast(message) { toastController.show(message); }
 function ensureNutritionistAccess() { return session.ensureAuthenticated(); }
+
+function getChatConversationMetaElement() {
+  let element = document.getElementById('chatConversationMeta');
+
+  if (element) {
+    return element;
+  }
+
+  const headerGroup = document.querySelector('#floatingChat h3')?.parentElement;
+
+  if (!headerGroup) {
+    return null;
+  }
+
+  element = document.createElement('p');
+  element.id = 'chatConversationMeta';
+  element.className = 'mt-1 text-[11px] text-white/65';
+  headerGroup.appendChild(element);
+  return element;
+}
+
+function clearActiveConversation() {
+  state.activeConversation = null;
+  state.lastConversationSignature = '';
+}
+
+function ensureValidPatientSelections() {
+  const patientIds = new Set(state.patients.map((patient) => patient.id));
+
+  if (!state.patients.length) {
+    state.selectedPatientId = null;
+    state.activeFilterId = null;
+    state.chatPatientId = null;
+    clearActiveConversation();
+    return;
+  }
+
+  if (!patientIds.has(state.selectedPatientId)) {
+    state.selectedPatientId = state.patients[0].id;
+  }
+
+  if (state.activeFilterId && !patientIds.has(state.activeFilterId)) {
+    state.activeFilterId = null;
+  }
+
+  if (!patientIds.has(state.chatPatientId)) {
+    state.chatPatientId = state.selectedPatientId;
+    clearActiveConversation();
+  }
+
+  if (state.activeConversation && state.activeConversation.patient?.id !== state.chatPatientId) {
+    clearActiveConversation();
+  }
+}
+
+function getChatPatient() {
+  return state.patients.find((patient) => patient.id === state.chatPatientId) || null;
+}
+
+function buildConversationSignature(conversation) {
+  const messages = Array.isArray(conversation?.messages) ? conversation.messages : [];
+  const latestMessage = messages[messages.length - 1] || null;
+
+  return JSON.stringify({
+    patientId: conversation?.patient?.id || '',
+    count: messages.length,
+    latestId: latestMessage?.id || '',
+    latestRole: latestMessage?.senderRole || '',
+    latestTime: latestMessage?.timeLabel || '',
+    pendingMessages: conversation?.patient?.pendingMessages || 0,
+  });
+}
+
+function updateChatPatientSummary(conversation) {
+  const patient = state.patients.find((item) => item.id === conversation?.patient?.id);
+
+  if (!patient || !conversation?.patient) {
+    return;
+  }
+
+  patient.pendingMessages = conversation.patient.pendingMessages || 0;
+  patient.lastMessageTime = conversation.patient.latestMessageTime || '';
+}
+
+async function fetchConversation(patientId) {
+  return apiRequest(`/api/nutritionist/conversation?patientId=${encodeURIComponent(patientId)}`);
+}
+
+async function sendNutritionistChatMessage(payload) {
+  return apiRequest('/api/nutritionist/messages', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+}
 
 // BUSCANDO DADOS 
 async function fetchDatabaseData() {
@@ -51,10 +163,9 @@ async function fetchDatabaseData() {
     state.messages = data.messages || [];
     state.foods = data.foods || [];
 
-    if (state.patients.length > 0 && !state.selectedPatientId) {
-      state.selectedPatientId = state.patients[0].id;
-    }
+    ensureValidPatientSelections();
     renderAll();
+    await syncNutritionistRealtimeChat({ forceRender: true, allowHidden: true, silent: true });
   } catch (error) { showToast('Erro ao conectar ao banco de dados.'); }
 }
 
@@ -64,6 +175,7 @@ function renderAll() {
   renderSelectedPatient();
   renderGeneralLists();
   populatePatientSelects();
+  renderChatPanel();
 }
 
 function renderHeader() {
@@ -88,6 +200,13 @@ function renderPatientsList() {
     const patientName = patient.name || 'Paciente';
     const isSelected = patient.id === state.selectedPatientId;
     const isFiltered = patient.id === state.activeFilterId;
+    const pendingMessages = Number(patient.pendingMessages || 0);
+    const pendingBadge = pendingMessages > 0
+      ? `<span class="inline-flex rounded-full bg-amber-100 px-2 py-1 text-[10px] font-bold uppercase tracking-[0.12em] text-amber-700">${pendingMessages} nova${pendingMessages === 1 ? '' : 's'}</span>`
+      : '';
+    const lastMessageTime = patient.lastMessageTime
+      ? `<span class="text-[11px] font-semibold text-nutriflow-500">Chat ${escapeHtml(patient.lastMessageTime)}</span>`
+      : '';
     
     const row = document.createElement('div');
     row.className = `p-4 flex items-center justify-between hover:bg-nutriflow-50 cursor-pointer transition ${isSelected ? 'bg-nutriflow-50 border-l-4 border-nutriflow-500' : ''} ${isFiltered ? 'ring-2 ring-nutriflow-200' : ''}`;
@@ -96,7 +215,8 @@ function renderPatientsList() {
       <div class="flex items-center gap-3">
         <div class="grid h-10 w-10 place-items-center rounded-xl bg-nutriflow-100 text-sm font-bold text-nutriflow-900">${getInitials(patientName)}</div>
         <div>
-          <p class="font-bold text-nutriflow-950 text-sm">${patientName}</p>
+          <p class="font-bold text-nutriflow-950 text-sm">${escapeHtml(patientName)}</p>
+          <div class="mt-1 flex flex-wrap gap-2">${pendingBadge}${lastMessageTime}</div>
           <p class="text-xs text-nutriflow-600">${patient.objective || 'Em avaliação'}</p>
         </div>
       </div>
@@ -107,7 +227,10 @@ function renderPatientsList() {
       if (!e.target.closest('button')) {
         state.selectedPatientId = patient.id;
         state.activeFilterId = patient.id; // Ativa o filtro para este paciente!
+        state.chatPatientId = patient.id;
+        clearActiveConversation();
         renderAll(); // Re-renderiza a tela para aplicar o filtro
+        void syncNutritionistRealtimeChat({ forceRender: true, allowHidden: true, silent: true });
       }
     });
     list.appendChild(row);
@@ -116,11 +239,21 @@ function renderPatientsList() {
 
 function renderSelectedPatient() {
   const patient = state.patients.find(p => p.id === state.selectedPatientId);
-  if (!patient) return;
+
+  if (!patient) {
+    document.getElementById('selectedPatientName').textContent = 'Nenhum selecionado';
+    document.getElementById('selectedPatientWeight').textContent = '--';
+    document.getElementById('selectedPatientHeight').textContent = '--';
+    document.getElementById('selectedPatientBodyFat').textContent = '--';
+    document.getElementById('selectedPatientViewButton').onclick = null;
+    document.getElementById('btnClearSelection')?.classList.add('hidden');
+    return;
+  }
   
   document.getElementById('selectedPatientName').textContent = patient.name;
   document.getElementById('selectedPatientWeight').textContent = patient.weight ? `${patient.weight}kg` : '--';
   document.getElementById('selectedPatientHeight').textContent = patient.height ? `${patient.height}m` : '--';
+  document.getElementById('selectedPatientBodyFat').textContent = patient.bodyFat ? `${patient.bodyFat}%` : '--';
   document.getElementById('selectedPatientViewButton').onclick = () => window.openPatientProfile(patient.id);
 
   const clearBtn = document.getElementById('btnClearSelection');
@@ -151,6 +284,38 @@ function renderPatientProfileModal(patient) {
       : patientAssessments.length
         ? patientAssessments.slice(0, 3).map(a => `<span class="bg-white border px-3 py-1 rounded-lg text-sm font-bold text-nutriflow-950">${a.weight}kg</span>`).join('')
       : '<span class="text-xs text-nutriflow-500 font-bold">Sem registros</span>';
+  }
+
+  const bodyMeasurements = patient.bodyMeasurements || { latest: [], history: [] };
+  const measurementsContainer = document.getElementById('patientProfileBodyMeasurements');
+  if (measurementsContainer) {
+    measurementsContainer.innerHTML = bodyMeasurements.latest?.length
+      ? bodyMeasurements.latest.map((measurement) => `
+          <div class="rounded-xl border border-nutriflow-100 bg-nutriflow-50 px-3 py-3">
+            <p class="text-[11px] font-bold uppercase tracking-[0.12em] text-nutriflow-500">${escapeHtml(measurement.label)}</p>
+            <p class="mt-2 text-base font-bold text-nutriflow-950">${escapeHtml(measurement.valueLabel)}</p>
+            <p class="text-[11px] text-nutriflow-500">${escapeHtml(measurement.dateLabel)}</p>
+          </div>
+        `).join('')
+      : '<p class="text-xs text-nutriflow-500">Nenhuma medida corporal registrada ainda.</p>';
+  }
+
+  const measurementsHistoryContainer = document.getElementById('patientProfileBodyMeasurementHistory');
+  if (measurementsHistoryContainer) {
+    measurementsHistoryContainer.innerHTML = bodyMeasurements.history?.length
+      ? bodyMeasurements.history.map((group) => `
+          <div class="rounded-xl border border-nutriflow-100 bg-nutriflow-50 px-3 py-3">
+            <p class="text-xs font-bold uppercase tracking-[0.12em] text-nutriflow-500">${escapeHtml(group.dateLabel)}</p>
+            <div class="mt-2 flex flex-wrap gap-2">
+              ${group.items.map((measurement) => `
+                <span class="rounded-full border border-white bg-white px-3 py-1 text-xs font-bold text-nutriflow-950">
+                  ${escapeHtml(measurement.label)}: ${escapeHtml(measurement.valueLabel)}
+                </span>
+              `).join('')}
+            </div>
+          </div>
+        `).join('')
+      : '<p class="text-xs text-nutriflow-500">Sem historico de medidas complementares por enquanto.</p>';
   }
 
   const mealsList = document.getElementById('patientProfileMealsList');
@@ -197,6 +362,96 @@ function buildMealTimeOptions(selectedMealTime = 'Almoco') {
   return MEAL_PLAN_MEAL_TIMES.map((mealTime) => `
     <option value="${mealTime}" ${mealTime === selectedMealTime ? 'selected' : ''}>${mealTime}</option>
   `).join('');
+}
+
+function toDateInputValue(date = new Date()) {
+  const baseDate = date instanceof Date ? date : new Date(date || Date.now());
+  const timezoneOffset = baseDate.getTimezoneOffset() * 60000;
+  return new Date(baseDate.getTime() - timezoneOffset).toISOString().slice(0, 10);
+}
+
+function getSelectedPatient() {
+  return state.patients.find((patient) => patient.id === state.selectedPatientId) || state.patients[0] || null;
+}
+
+function getAssessmentMeasurementsPayload(options = {}) {
+  const allowIncomplete = options.allowIncomplete === true;
+
+  return Array.from(document.querySelectorAll('[data-assessment-measurement-row]')).map((row) => {
+    const label = row.querySelector('[data-assessment-measurement-label]')?.value || '';
+    const value = row.querySelector('[data-assessment-measurement-value]')?.value || '';
+    const unit = row.querySelector('[data-assessment-measurement-unit]')?.value || '';
+
+    return {
+      label: label.trim(),
+      value: value.trim(),
+      unit: unit.trim(),
+    };
+  }).filter((measurement) => (
+    allowIncomplete
+      ? (measurement.label || measurement.value || measurement.unit)
+      : (measurement.label && measurement.value)
+  ));
+}
+
+function addAssessmentMeasurementRow(measurement = {}) {
+  const list = document.getElementById('assessmentMeasurementsList');
+
+  if (!list) {
+    return;
+  }
+
+  const row = document.createElement('div');
+  row.className = 'grid gap-2 rounded-lg border border-white bg-white p-2 shadow-sm md:grid-cols-[1.2fr_140px_110px_auto]';
+  row.dataset.assessmentMeasurementRow = 'true';
+  row.innerHTML = `
+    <input class="rounded-lg border border-nutriflow-200 px-3 py-2 text-sm font-bold" data-assessment-measurement-label type="text" maxlength="40" placeholder="Ex: Cintura" value="${escapeHtml(measurement.label || '')}" />
+    <input class="rounded-lg border border-nutriflow-200 px-3 py-2 text-sm font-bold" data-assessment-measurement-value type="number" min="0.1" max="500" step="0.1" placeholder="82.5" value="${escapeHtml(String(measurement.value || ''))}" />
+    <input class="rounded-lg border border-nutriflow-200 px-3 py-2 text-sm font-bold" data-assessment-measurement-unit type="text" maxlength="12" placeholder="cm" value="${escapeHtml(measurement.unit || 'cm')}" />
+    <button class="rounded-lg border border-red-100 px-3 py-2 text-xs font-bold text-red-500" type="button" data-remove-assessment-measurement>Remover</button>
+  `;
+
+  row.querySelector('[data-remove-assessment-measurement]')?.addEventListener('click', () => {
+    row.remove();
+  });
+
+  list.appendChild(row);
+}
+
+function resetAssessmentForm() {
+  document.getElementById('assessmentForm')?.reset();
+
+  const patient = getSelectedPatient();
+  const patientSelect = document.getElementById('assessmentPatient');
+  const dateInput = document.getElementById('assessmentDate');
+  const weightInput = document.getElementById('assessmentWeight');
+  const heightInput = document.getElementById('assessmentHeight');
+  const bodyFatInput = document.getElementById('assessmentBodyFat');
+  const measurementsList = document.getElementById('assessmentMeasurementsList');
+
+  if (patientSelect && patient?.id) {
+    patientSelect.value = patient.id;
+  }
+
+  if (dateInput) {
+    dateInput.value = toDateInputValue(new Date());
+  }
+
+  if (weightInput) {
+    weightInput.value = patient?.weight || '';
+  }
+
+  if (heightInput) {
+    heightInput.value = patient?.height || '';
+  }
+
+  if (bodyFatInput) {
+    bodyFatInput.value = patient?.bodyFat || '';
+  }
+
+  if (measurementsList) {
+    measurementsList.innerHTML = '';
+  }
 }
 
 function getMealPlanItemsPayload(options = {}) {
@@ -287,6 +542,233 @@ function resetMealPlanBuilder(plan = null) {
   updateMealPlanTotals();
 }
 
+function getPendingMessagesLabel(count) {
+  if (!count) {
+    return 'Conversa em dia.';
+  }
+
+  return count === 1
+    ? '1 mensagem aguardando resposta.'
+    : `${count} mensagens aguardando resposta.`;
+}
+
+function syncChatComposerState(patient) {
+  const isLoadingLocked = state.isLoadingConversation && !state.activeConversation;
+  const isDisabled = !patient || state.isSendingChatMessage || isLoadingLocked;
+
+  if (chatInput) {
+    chatInput.disabled = isDisabled;
+    chatInput.placeholder = patient
+      ? `Responder ${patient.name}...`
+      : 'Selecione um paciente para iniciar o chat';
+  }
+
+  if (chatSubmitButton) {
+    chatSubmitButton.disabled = isDisabled;
+    chatSubmitButton.textContent = state.isSendingChatMessage ? 'Enviando...' : 'Enviar';
+    chatSubmitButton.classList.toggle('opacity-50', isDisabled);
+    chatSubmitButton.classList.toggle('cursor-not-allowed', isDisabled);
+  }
+}
+
+function renderChatPanel(options = {}) {
+  const patient = getChatPatient();
+  const conversation = state.activeConversation;
+  const messages = Array.isArray(conversation?.messages) ? conversation.messages : [];
+  const metaElement = getChatConversationMetaElement();
+
+  if (chatPatientSelect && chatPatientSelect.value !== (state.chatPatientId || '')) {
+    chatPatientSelect.value = state.chatPatientId || '';
+  }
+
+  if (metaElement) {
+    if (!patient) {
+      metaElement.textContent = 'Selecione um paciente para carregar a conversa.';
+    } else if (state.isLoadingConversation && !conversation) {
+      metaElement.textContent = `Carregando conversa com ${patient.name}...`;
+    } else if (conversation?.patient?.pendingMessages) {
+      metaElement.textContent = getPendingMessagesLabel(conversation.patient.pendingMessages);
+    } else if (conversation?.patient?.latestMessageTime) {
+      metaElement.textContent = `Ultima atividade: ${conversation.patient.latestMessageTime}`;
+    } else {
+      metaElement.textContent = `Sem mensagens com ${patient.name} ainda.`;
+    }
+  }
+
+  syncChatComposerState(patient);
+
+  if (!chatMessages) {
+    return;
+  }
+
+  if (!patient) {
+    chatMessages.innerHTML = '<p class="mt-10 text-center text-xs text-nutriflow-500">Selecione um paciente para iniciar.</p>';
+    return;
+  }
+
+  if (state.isLoadingConversation && !conversation) {
+    chatMessages.innerHTML = '<p class="mt-10 text-center text-xs font-bold uppercase tracking-[0.12em] text-nutriflow-500">Carregando conversa...</p>';
+    return;
+  }
+
+  if (!messages.length) {
+    chatMessages.innerHTML = `
+      <div class="rounded-[24px] border border-dashed border-nutriflow-200 bg-white p-5 text-sm leading-7 text-nutriflow-600">
+        Nenhuma mensagem com ${escapeHtml(patient.name)} ainda. Use o campo abaixo para iniciar a conversa.
+      </div>
+    `;
+    return;
+  }
+
+  chatMessages.innerHTML = messages.map((message) => {
+    const isNutritionistMessage = message.senderRole === 'NUTRITIONIST';
+    const senderName = message.senderName || (isNutritionistMessage ? state.currentUser?.name : patient.name);
+
+    return `
+      <div class="chat-row${isNutritionistMessage ? ' is-user' : ''}">
+        ${isNutritionistMessage ? '' : `<div class="chat-avatar">${escapeHtml(getInitials(patient.name))}</div>`}
+        <div class="chat-bubble${isNutritionistMessage ? ' is-user' : ''}">
+          <p class="${isNutritionistMessage ? 'text-xs font-semibold uppercase tracking-[0.14em] text-white/60' : 'text-xs font-semibold uppercase tracking-[0.14em] text-nutriflow-500'}">
+            ${escapeHtml(senderName)} - ${escapeHtml(message.timeLabel || 'agora')}
+          </p>
+          <p class="mt-2 text-sm leading-7">${escapeHtml(message.content)}</p>
+          ${!isNutritionistMessage && message.pending ? '<span class="mt-2 inline-flex rounded-full bg-amber-100 px-2 py-1 text-[10px] font-bold uppercase tracking-[0.14em] text-amber-700">Aguardando resposta</span>' : ''}
+        </div>
+      </div>
+    `;
+  }).join('');
+
+  if (options.scrollToEnd !== false) {
+    window.requestAnimationFrame(() => {
+      chatMessages.scrollTop = chatMessages.scrollHeight;
+    });
+  }
+}
+
+async function syncNutritionistRealtimeChat(options = {}) {
+  const patientId = String(options.patientId || state.chatPatientId || '').trim();
+
+  if (!patientId || nutritionistChatSyncInFlight || !session.getToken() || (document.hidden && !options.allowHidden)) {
+    return;
+  }
+
+  const requestedPatientId = patientId;
+  nutritionistChatSyncInFlight = true;
+  state.isLoadingConversation = true;
+
+  if (options.forceRender) {
+    renderChatPanel();
+  }
+
+  try {
+    const conversation = await fetchConversation(requestedPatientId);
+
+    if (state.chatPatientId && state.chatPatientId !== requestedPatientId && !options.overrideSelection) {
+      return;
+    }
+
+    state.chatPatientId = requestedPatientId;
+    updateChatPatientSummary(conversation);
+
+    const nextSignature = buildConversationSignature(conversation);
+    const shouldRender = options.forceRender || nextSignature !== state.lastConversationSignature || !state.activeConversation;
+
+    state.activeConversation = conversation;
+    state.lastConversationSignature = nextSignature;
+
+    if (shouldRender) {
+      renderPatientsList();
+      renderSelectedPatient();
+      populatePatientSelects();
+      renderChatPanel();
+    }
+  } catch (error) {
+    if (!options.silent && error.message !== 'Sessao invalida.') {
+      showToast(error.message || 'Nao foi possivel carregar a conversa.');
+    }
+  } finally {
+    state.isLoadingConversation = false;
+    nutritionistChatSyncInFlight = false;
+    renderChatPanel({ scrollToEnd: false });
+  }
+}
+
+function stopNutritionistRealtimeChat() {
+  if (!nutritionistChatSyncIntervalId) {
+    return;
+  }
+
+  window.clearInterval(nutritionistChatSyncIntervalId);
+  nutritionistChatSyncIntervalId = null;
+}
+
+function startNutritionistRealtimeChat() {
+  if (nutritionistChatSyncIntervalId || !session.getToken()) {
+    return;
+  }
+
+  nutritionistChatSyncIntervalId = window.setInterval(() => {
+    void syncNutritionistRealtimeChat({ silent: true });
+  }, 3500);
+}
+
+function syncNutritionistRealtimeAvailability() {
+  if (!session.getToken()) {
+    stopNutritionistRealtimeChat();
+    return;
+  }
+
+  startNutritionistRealtimeChat();
+}
+
+async function handleNutritionistChatSubmit(event) {
+  event.preventDefault();
+
+  const patient = getChatPatient();
+  const content = chatInput?.value.trim() || '';
+
+  if (!patient) {
+    showToast('Selecione um paciente para enviar a mensagem.');
+    return;
+  }
+
+  if (!content) {
+    showToast('Digite uma mensagem para enviar.');
+    chatInput?.focus();
+    return;
+  }
+
+  state.isSendingChatMessage = true;
+  renderChatPanel();
+
+  try {
+    const result = await sendNutritionistChatMessage({
+      patientId: patient.id,
+      content,
+    });
+
+    if (chatInput) {
+      chatInput.value = '';
+    }
+
+    await syncNutritionistRealtimeChat({
+      patientId: patient.id,
+      forceRender: true,
+      allowHidden: true,
+      silent: true,
+      overrideSelection: true,
+    });
+
+    showToast(result.message || 'Resposta enviada para o paciente.');
+  } catch (error) {
+    showToast(error.message || 'Nao foi possivel enviar a resposta.');
+  } finally {
+    state.isSendingChatMessage = false;
+    renderChatPanel();
+    chatInput?.focus();
+  }
+}
+
 function renderGeneralLists() {
   const pId = state.activeFilterId;
 
@@ -315,6 +797,7 @@ function renderGeneralLists() {
         <p class="text-xs font-bold text-nutriflow-500 uppercase">${ass.patient}</p>
         <p class="text-sm font-bold text-nutriflow-950 mt-1">Peso: ${ass.weight}kg</p>
         <p class="text-xs font-semibold text-nutriflow-600">${new Date(ass.date).toLocaleDateString()}</p>
+        <p class="mt-1 text-xs text-nutriflow-500">${ass.measurements?.length ? `${ass.measurements.length} medidas registradas` : 'Sem medidas complementares'}</p>
         <button onclick="window.deleteResource('assessments', '${ass.id}')" class="absolute top-2 right-2 p-1 text-red-400 hover:text-red-600 opacity-0 group-hover:opacity-100 transition">🗑️</button>
       </div>
     `).join('') : '<p class="text-sm text-nutriflow-500">Nenhuma avaliação.</p>';
@@ -367,7 +850,15 @@ function renderGeneralLists() {
 }
 
 function populatePatientSelects() {
-  const options = state.patients.map((p) => `<option value="${p.id}">${p.name}</option>`).join('');
+  const options = state.patients.map((patient) => {
+    const pendingMessages = Number(patient.pendingMessages || 0);
+    const label = pendingMessages > 0
+      ? `${patient.name} (${pendingMessages} nova${pendingMessages === 1 ? '' : 's'})`
+      : patient.name;
+
+    return `<option value="${patient.id}">${escapeHtml(label)}</option>`;
+  }).join('');
+
   ['mealPlanPatient', 'assessmentPatient', 'appointmentPatient', 'chatPatientSelect', 'challengePatient', 'addPartPatient'].forEach(id => {
     const el = document.getElementById(id);
     if(el) {
@@ -375,7 +866,11 @@ function populatePatientSelects() {
       else if (id === 'challengePatient') el.innerHTML = '<option value="">Todos os pacientes (Geral)</option>' + options;
       else el.innerHTML = options;
       
-      if (state.selectedPatientId && id !== 'chatPatientSelect' && id !== 'challengePatient' && id !== 'addPartPatient') el.value = state.selectedPatientId;
+      if (id === 'chatPatientSelect') {
+        el.value = state.chatPatientId || '';
+      } else if (state.selectedPatientId && id !== 'challengePatient' && id !== 'addPartPatient') {
+        el.value = state.selectedPatientId;
+      }
     }
   });
 }
@@ -450,6 +945,7 @@ function closeModal(modalId) {
 
 window.openPatientProfile = function(patientId) {
   state.selectedPatientId = patientId;
+  state.chatPatientId = patientId;
   renderSelectedPatient();
   renderPatientProfileModal(state.patients.find(p => p.id === patientId));
   openModal('patientProfile');
@@ -463,7 +959,7 @@ function bindButtons() {
     resetMealPlanBuilder();
     openModal('mealPlan');
   });
-  document.getElementById('btnOpenAssessment')?.addEventListener('click', () => { document.getElementById('assessmentForm').reset(); openModal('assessment'); });
+  document.getElementById('btnOpenAssessment')?.addEventListener('click', () => { resetAssessmentForm(); openModal('assessment'); });
   document.getElementById('btnOpenAppointment')?.addEventListener('click', () => { document.getElementById('appointmentForm').reset(); openModal('appointment'); });
   document.getElementById('btnOpenChallenge')?.addEventListener('click', () => { document.getElementById('challengeForm').reset(); openModal('challenge'); });
   
@@ -474,12 +970,31 @@ function bindButtons() {
     openModal('mealPlan');
   });
   document.getElementById('btnAddMealPlanItem')?.addEventListener('click', () => addMealPlanItemRow());
-  document.getElementById('btnProfileNewAssessment')?.addEventListener('click', () => { document.getElementById('assessmentForm').reset(); openModal('assessment'); });
+  document.getElementById('btnAddAssessmentMeasurement')?.addEventListener('click', () => addAssessmentMeasurementRow());
+  document.getElementById('btnProfileNewAssessment')?.addEventListener('click', () => { resetAssessmentForm(); openModal('assessment'); });
 
   document.querySelectorAll('[data-close]').forEach(btn => {
     btn.addEventListener('click', (e) => { e.preventDefault(); closeModal(e.target.dataset.close); });
   });
   document.getElementById('logoutButton')?.addEventListener('click', () => { session.clear(); window.location.href = 'index.html'; });
+
+  chatPatientSelect?.addEventListener('change', (event) => {
+    state.chatPatientId = event.target.value || null;
+    clearActiveConversation();
+    renderChatPanel();
+
+    if (state.chatPatientId) {
+      void syncNutritionistRealtimeChat({ forceRender: true, allowHidden: true, silent: true });
+    }
+  });
+
+  chatForm?.addEventListener('submit', handleNutritionistChatSubmit);
+  document.addEventListener('visibilitychange', () => {
+    if (!document.hidden) {
+      void syncNutritionistRealtimeChat({ forceRender: true, silent: true });
+    }
+  });
+  window.addEventListener('beforeunload', stopNutritionistRealtimeChat);
 }
 
 // INTEGRAÇÕES REAIS
@@ -521,12 +1036,16 @@ document.getElementById('mealPlanForm')?.addEventListener('submit', async (e) =>
 
 document.getElementById('assessmentForm')?.addEventListener('submit', async (e) => {
   e.preventDefault();
+  const dateValue = document.getElementById('assessmentDate').value;
+  const recordedAt = dateValue ? new Date(`${dateValue}T12:00:00`) : new Date();
   const payload = {
     patientId: document.getElementById('assessmentPatient').value,
     weight: document.getElementById('assessmentWeight').value,
     height: document.getElementById('assessmentHeight').value,
     bodyFat: document.getElementById('assessmentBodyFat').value,
-    date: new Date().toISOString()
+    notes: document.getElementById('assessmentNotes').value,
+    measurements: getAssessmentMeasurementsPayload(),
+    date: Number.isNaN(recordedAt.getTime()) ? new Date().toISOString() : recordedAt.toISOString()
   };
   try {
     await apiRequest('/api/nutritionist/assessments', { method: 'POST', body: JSON.stringify(payload) });
@@ -573,10 +1092,47 @@ document.getElementById('addParticipantForm')?.addEventListener('submit', async 
   } catch(err) { showToast('Erro ao adicionar paciente.'); }
 });
 
+// LOGIC PARA O CHAT FLUTUANTE
+function openChatModal() {
+  if (!chatModal) {
+    return;
+  }
+
+  if (!state.chatPatientId && state.selectedPatientId) {
+    state.chatPatientId = state.selectedPatientId;
+  }
+
+  chatModal.classList.remove('chat-hidden');
+  chatModal.classList.add('chat-visible');
+  renderChatPanel();
+  void syncNutritionistRealtimeChat({ forceRender: true, allowHidden: true, silent: true });
+}
+
+function closeChatModal() {
+  if (!chatModal) {
+    return;
+  }
+
+  chatModal.classList.add('chat-hidden');
+  chatModal.classList.remove('chat-visible');
+}
+
+document.getElementById('btnToggleChat')?.addEventListener('click', () => {
+  if (chatModal?.classList.contains('chat-hidden')) {
+    openChatModal();
+    return;
+  }
+
+  closeChatModal();
+});
+
+document.getElementById('btnCloseChat')?.addEventListener('click', closeChatModal);
+
 // START
 async function init() {
   if (!ensureNutritionistAccess()) return;
-  bindButtons(); 
+  bindButtons();
+  syncNutritionistRealtimeAvailability();
   await fetchDatabaseData();
 }
 init();

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -77,6 +77,7 @@
           <a class="sidebar-link" href="#refeicoes"><span>Refeições</span></a>
           <a class="sidebar-link" href="#historico"><span>Histórico</span></a>
           <a class="sidebar-link" href="#plano"><span>Plano alimentar</span></a>
+          <a class="sidebar-link" href="#medidas"><span>Medidas corporais</span></a>
           <a class="sidebar-link" href="#peso"><span>Evolução de peso</span></a>
         </nav>
       </div>
@@ -237,6 +238,22 @@
                 </div>
               </div>
               <div id="planSections" class="mt-6 space-y-4"></div>
+            </article>
+
+            <article id="medidas" class="dashboard-surface dashboard-card rounded-[30px] p-6 md:p-7">
+              <div class="flex items-center justify-between gap-4">
+                <div>
+                  <span class="glass-pill">Avaliacao corporal</span>
+                  <h2 class="mt-4 text-2xl font-bold tracking-[-0.05em]">Medidas corporais</h2>
+                </div>
+              </div>
+              <div id="bodyMeasurementsSummary" class="mt-6 grid gap-4 sm:grid-cols-2 xl:grid-cols-3"></div>
+              <div class="mt-5 overflow-hidden rounded-[22px] border border-nutriflow-200 bg-white">
+                <div class="bg-nutriflow-50 px-4 py-3 text-xs font-bold uppercase tracking-[0.14em] text-nutriflow-600">
+                  Historico por avaliacao
+                </div>
+                <div id="bodyMeasurementsHistoryList" class="divide-y divide-nutriflow-100 text-sm font-medium"></div>
+              </div>
             </article>
 
             <article id="peso" class="dashboard-surface dashboard-card rounded-[30px] p-6 md:p-7">

--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -1234,6 +1234,44 @@ function renderPlan() {
   `;
 }
 
+function renderBodyMeasurements() {
+  const bodyMeasurements = state.dashboard?.bodyMeasurements || {
+    latest: [],
+    history: [],
+  };
+  const summaryContainer = document.getElementById('bodyMeasurementsSummary');
+  const historyContainer = document.getElementById('bodyMeasurementsHistoryList');
+
+  if (summaryContainer) {
+    summaryContainer.innerHTML = bodyMeasurements.latest.length
+      ? bodyMeasurements.latest.map((measurement) => `
+          <article class="rounded-[24px] border border-nutriflow-200 bg-white p-4">
+            <p class="text-xs font-bold uppercase tracking-[0.16em] text-nutriflow-500">${escapeHtml(measurement.label)}</p>
+            <p class="mt-3 text-2xl font-bold tracking-[-0.04em] text-nutriflow-950">${escapeHtml(measurement.valueLabel)}</p>
+            <p class="mt-2 text-xs font-medium text-nutriflow-600">Ultimo registro: ${escapeHtml(measurement.dateLabel)}</p>
+          </article>
+        `).join('')
+      : '<div class="rounded-[24px] border border-dashed border-nutriflow-200 bg-white px-4 py-5 text-sm text-nutriflow-600 sm:col-span-2 xl:col-span-3">Sua nutricionista ainda nao registrou medidas corporais por avaliacao.</div>';
+  }
+
+  if (historyContainer) {
+    historyContainer.innerHTML = bodyMeasurements.history.length
+      ? bodyMeasurements.history.map((group) => `
+          <div class="px-4 py-4">
+            <p class="text-xs font-bold uppercase tracking-[0.14em] text-nutriflow-500">${escapeHtml(group.dateLabel)}</p>
+            <div class="mt-3 flex flex-wrap gap-2">
+              ${group.items.map((measurement) => `
+                <span class="rounded-full border border-nutriflow-100 bg-nutriflow-50 px-3 py-2 text-xs font-bold text-nutriflow-950">
+                  ${escapeHtml(measurement.label)}: ${escapeHtml(measurement.valueLabel)}
+                </span>
+              `).join('')}
+            </div>
+          </div>
+        `).join('')
+      : '<div class="px-4 py-4 text-sm text-nutriflow-600">Nenhum historico de medidas corporais disponivel ainda.</div>';
+  }
+}
+
 function renderWeightChart(labels, values) {
   const svg = document.getElementById('weightChart');
   const labelsContainer = document.getElementById('weightChartLabels');
@@ -1454,6 +1492,7 @@ function renderDashboard() {
   renderMeals();
   renderHistory();
   renderPlan();
+  renderBodyMeasurements();
   renderWeight();
   renderChat();
   renderClinical();

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,5 +1,6 @@
 generator client {
   provider = "prisma-client-js"
+  engineType = "binary"
 }
 
 datasource db {
@@ -53,6 +54,7 @@ model PatientProfile {
   mealEntries       MealEntry[]
   weightEntries     WeightEntry[]
   progressSnapshots ProgressSnapshot[]
+  bodyMeasurements  BodyMeasurement[]
   challengeLinks    ChallengeParticipant[]
   goal              Goal?
 }
@@ -101,6 +103,26 @@ model Assessment {
   updatedAt        DateTime       @updatedAt
   patientProfile   PatientProfile @relation(fields: [patientProfileId], references: [id], onDelete: Cascade)
   nutritionist     User           @relation("NutritionistAssessments", fields: [nutritionistId], references: [id], onDelete: Cascade)
+  bodyMeasurements BodyMeasurement[]
+}
+
+model BodyMeasurement {
+  id               String         @id @default(uuid())
+  assessmentId     String
+  patientProfileId String
+  key              String
+  label            String
+  unit             String
+  value            Float
+  recordedAt       DateTime
+  createdAt        DateTime       @default(now())
+  updatedAt        DateTime       @updatedAt
+  assessment       Assessment     @relation(fields: [assessmentId], references: [id], onDelete: Cascade)
+  patientProfile   PatientProfile @relation(fields: [patientProfileId], references: [id], onDelete: Cascade)
+
+  @@unique([assessmentId, key])
+  @@index([patientProfileId, recordedAt])
+  @@index([patientProfileId, key, recordedAt])
 }
 
 model PatientMessage {

--- a/src/repositories/nutritionistDashboardRepository.js
+++ b/src/repositories/nutritionistDashboardRepository.js
@@ -1,3 +1,5 @@
+const { buildAssessmentMeasurements } = require('../utils/bodyMeasurements');
+
 const DEFAULT_FOODS = [
   { name: 'Arroz integral cozido', calories: 124, protein: 3, carbs: 26, fat: 1 },
   { name: 'Feijao carioca cozido', calories: 76, protein: 5, carbs: 14, fat: 1 },
@@ -109,6 +111,11 @@ class NutritionistDashboardRepository {
           bodyFat: 31.4,
           notes: 'Boa adesao e melhora no lanche da tarde.',
         },
+        measurements: [
+          { label: 'Cintura', unit: 'cm', value: 86.4 },
+          { label: 'Quadril', unit: 'cm', value: 109.2 },
+          { label: 'Braco', unit: 'cm', value: 31.8 },
+        ],
         appointment: {
           scheduledAt: daysFromNow(2, 16, 30),
           type: 'Retorno semanal',
@@ -184,6 +191,11 @@ class NutritionistDashboardRepository {
           bodyFat: 18.8,
           notes: 'Boa evolucao de carga, revisar distribuicao de carboidratos no pos-treino.',
         },
+        measurements: [
+          { label: 'Torax', unit: 'cm', value: 104.3 },
+          { label: 'Braco relaxado', unit: 'cm', value: 38.2 },
+          { label: 'Coxa', unit: 'cm', value: 61.5 },
+        ],
         appointment: {
           scheduledAt: daysFromNow(3, 11, 0),
           type: 'Ajuste de macros',
@@ -245,6 +257,11 @@ class NutritionistDashboardRepository {
           bodyFat: 27.2,
           notes: 'Melhor regularidade e sono mais estavel.',
         },
+        measurements: [
+          { label: 'Cintura', unit: 'cm', value: 78.1 },
+          { label: 'Abdomen', unit: 'cm', value: 84.6 },
+          { label: 'Quadril', unit: 'cm', value: 98.4 },
+        ],
         appointment: {
           scheduledAt: daysFromNow(4, 14, 15),
           type: 'Revisao de rotina',
@@ -306,6 +323,11 @@ class NutritionistDashboardRepository {
           bodyFat: 33.1,
           notes: 'Baixa frequencia de registros e necessidade de retomar rotina.',
         },
+        measurements: [
+          { label: 'Cintura', unit: 'cm', value: 103.8 },
+          { label: 'Abdomen', unit: 'cm', value: 108.9 },
+          { label: 'Quadril', unit: 'cm', value: 111.5 },
+        ],
         appointment: {
           scheduledAt: daysFromNow(6, 9, 0),
           type: 'Retomada de acompanhamento',
@@ -407,12 +429,31 @@ class NutritionistDashboardRepository {
           },
         });
 
-        await tx.assessment.create({
+        const assessment = await tx.assessment.create({
           data: {
             patientProfileId: profile.id,
             nutritionistId,
             ...seed.assessment,
           },
+        });
+
+        await tx.bodyMeasurement.createMany({
+          data: buildAssessmentMeasurements({
+            weight: seed.assessment.weight,
+            height: seed.assessment.height,
+            bodyFat: seed.assessment.bodyFat,
+            imc: seed.assessment.imc,
+            recordedAt: seed.assessment.date,
+            extraMeasurements: seed.measurements || [],
+          }).map((measurement) => ({
+            assessmentId: assessment.id,
+            patientProfileId: profile.id,
+            key: measurement.key,
+            label: measurement.label,
+            unit: measurement.unit,
+            value: measurement.value,
+            recordedAt: measurement.recordedAt,
+          })),
         });
 
         await tx.appointment.create({
@@ -510,6 +551,7 @@ class NutritionistDashboardRepository {
             appointments: { orderBy: { scheduledAt: 'asc' } },
             weightEntries: { orderBy: { recordedAt: 'asc' } },
             progressSnapshots: { orderBy: { recordedAt: 'asc' } },
+            bodyMeasurements: { orderBy: { recordedAt: 'desc' } },
             mealEntries: { orderBy: { loggedAt: 'desc' }, take: 15 },
             challengeLinks: {
               include: { challenge: true },
@@ -526,7 +568,13 @@ class NutritionistDashboardRepository {
           },
           orderBy: { createdAt: 'desc' },
         },
-        assessments: { include: { patientProfile: { include: { user: true } } }, orderBy: { date: 'desc' } },
+        assessments: {
+          include: {
+            patientProfile: { include: { user: true } },
+            bodyMeasurements: { orderBy: { recordedAt: 'desc' } },
+          },
+          orderBy: { date: 'desc' },
+        },
         messages: { include: { patientProfile: { include: { user: true } } }, orderBy: { sentAt: 'desc' } },
         appointments: { include: { patientProfile: { include: { user: true } } }, orderBy: { scheduledAt: 'asc' } },
         challenges: { include: { participants: { include: { patientProfile: { include: { user: true } } } } }, orderBy: { createdAt: 'desc' } },
@@ -547,6 +595,9 @@ class NutritionistDashboardRepository {
         },
         progressSnapshots: {
           orderBy: { recordedAt: 'asc' },
+        },
+        bodyMeasurements: {
+          orderBy: { recordedAt: 'desc' },
         },
       },
     });
@@ -649,6 +700,18 @@ class NutritionistDashboardRepository {
         },
       });
 
+      await tx.bodyMeasurement.createMany({
+        data: (data.measurements || []).map((measurement) => ({
+          assessmentId: assessment.id,
+          patientProfileId: data.patientProfileId,
+          key: measurement.key,
+          label: measurement.label,
+          unit: measurement.unit,
+          value: measurement.value,
+          recordedAt: measurement.recordedAt || data.date,
+        })),
+      });
+
       await tx.patientProfile.update({
         where: { id: data.patientProfileId },
         data: {
@@ -713,6 +776,9 @@ class NutritionistDashboardRepository {
             include: {
               user: true,
             },
+          },
+          bodyMeasurements: {
+            orderBy: { recordedAt: 'desc' },
           },
         },
       });

--- a/src/repositories/patientDashboardRepository.js
+++ b/src/repositories/patientDashboardRepository.js
@@ -36,6 +36,9 @@ class PatientDashboardRepository {
         progressSnapshots: {
           orderBy: { recordedAt: 'asc' },
         },
+        bodyMeasurements: {
+          orderBy: { recordedAt: 'desc' },
+        },
         challengeLinks: {
           include: {
             challenge: true,
@@ -247,6 +250,9 @@ class PatientDashboardRepository {
           },
           progressSnapshots: {
             orderBy: { recordedAt: 'asc' },
+          },
+          bodyMeasurements: {
+            orderBy: { recordedAt: 'desc' },
           },
           challengeLinks: {
             include: {

--- a/src/services/nutritionistDashboardService.js
+++ b/src/services/nutritionistDashboardService.js
@@ -1,5 +1,14 @@
 const { AppError } = require('../errors/appError');
 const { isPatientRole } = require('../constants/roles');
+const {
+  CORE_BODY_MEASUREMENT_KEYS,
+  buildAssessmentMeasurements,
+  formatMeasurementValue,
+  getLatestMeasurementsByType,
+  groupMeasurementsByDate,
+  normalizeMeasurementKey,
+  roundMeasurementValue,
+} = require('../utils/bodyMeasurements');
 
 function normalizeEmail(value) {
   return String(value || '').trim().toLowerCase();
@@ -93,6 +102,14 @@ const APPOINTMENT_STATUSES = {
 };
 
 const ALLOWED_APPOINTMENT_STATUSES = new Set(Object.values(APPOINTMENT_STATUSES));
+const BODY_MEASUREMENT_RULES = {
+  maxItems: 12,
+  minValue: 0.1,
+  maxValue: 500,
+  maxLabelLength: 40,
+  maxUnitLength: 12,
+};
+const CHAT_MESSAGE_MAX_LENGTH = 500;
 
 function normalizeAppointmentStatus(value) {
   const normalized = normalizeText(value).toLowerCase();
@@ -158,6 +175,128 @@ function buildWeightTimeline(patientProfile) {
   return patientProfile.currentWeight
     ? [{ weight: patientProfile.currentWeight, recordedAt: new Date() }]
     : [];
+}
+
+function buildFallbackBodyMeasurements(patientProfile) {
+  if (patientProfile.assessments?.length) {
+    return patientProfile.assessments.flatMap((assessment) => buildAssessmentMeasurements({
+      weight: assessment.weight,
+      height: assessment.height,
+      bodyFat: assessment.bodyFat,
+      imc: assessment.imc,
+      recordedAt: assessment.date,
+    }).map((measurement) => ({
+      id: `${assessment.id}:${measurement.key}`,
+      ...measurement,
+    })));
+  }
+
+  if (!patientProfile.currentWeight && !patientProfile.height && !patientProfile.bodyFat) {
+    return [];
+  }
+
+  const recordedAt = patientProfile.lastAssessmentAt || patientProfile.updatedAt || new Date();
+  const imc = patientProfile.currentWeight > 0 && patientProfile.height > 0
+    ? patientProfile.currentWeight / (patientProfile.height * patientProfile.height)
+    : 0;
+
+  return buildAssessmentMeasurements({
+    weight: patientProfile.currentWeight,
+    height: patientProfile.height,
+    bodyFat: patientProfile.bodyFat,
+    imc,
+    recordedAt,
+  })
+    .filter((measurement) => measurement.value > 0)
+    .map((measurement) => ({
+      id: `profile:${measurement.key}`,
+      ...measurement,
+    }));
+}
+
+function getBodyMeasurementsTimeline(patientProfile) {
+  if (patientProfile.bodyMeasurements?.length) {
+    return patientProfile.bodyMeasurements;
+  }
+
+  return buildFallbackBodyMeasurements(patientProfile);
+}
+
+function parseAdditionalMeasurements(measurements) {
+  if (!Array.isArray(measurements)) {
+    return [];
+  }
+
+  const normalizedRows = measurements
+    .map((measurement) => ({
+      label: normalizeText(measurement?.label),
+      unit: normalizeText(measurement?.unit),
+      value: measurement?.value,
+    }))
+    .filter((measurement) => (
+      measurement.label
+      || measurement.unit
+      || String(measurement.value ?? '').trim() !== ''
+    ));
+
+  if (normalizedRows.length > BODY_MEASUREMENT_RULES.maxItems) {
+    throw new AppError(
+      `Adicione no maximo ${BODY_MEASUREMENT_RULES.maxItems} medidas complementares por avaliacao.`,
+      400,
+    );
+  }
+
+  const parsedMeasurements = [];
+  const seenKeys = new Set(CORE_BODY_MEASUREMENT_KEYS);
+
+  normalizedRows.forEach((measurement, index) => {
+    const position = index + 1;
+
+    if (!measurement.label || measurement.label.length < 2 || measurement.label.length > BODY_MEASUREMENT_RULES.maxLabelLength) {
+      throw new AppError(
+        `Informe um nome valido entre 2 e ${BODY_MEASUREMENT_RULES.maxLabelLength} caracteres para a medida ${position}.`,
+        400,
+      );
+    }
+
+    const key = normalizeMeasurementKey(measurement.label);
+
+    if (!key) {
+      throw new AppError(`Nao foi possivel identificar a medida ${position}.`, 400);
+    }
+
+    if (seenKeys.has(key)) {
+      throw new AppError(`A medida "${measurement.label}" ja foi informada nesta avaliacao.`, 400);
+    }
+
+    const parsedValue = Number(measurement.value);
+
+    if (!Number.isFinite(parsedValue) || parsedValue < BODY_MEASUREMENT_RULES.minValue || parsedValue > BODY_MEASUREMENT_RULES.maxValue) {
+      throw new AppError(
+        `O valor da medida "${measurement.label}" deve ficar entre ${BODY_MEASUREMENT_RULES.minValue} e ${BODY_MEASUREMENT_RULES.maxValue}.`,
+        400,
+      );
+    }
+
+    const unit = measurement.unit || 'cm';
+
+    if (unit.length > BODY_MEASUREMENT_RULES.maxUnitLength) {
+      throw new AppError(
+        `A unidade da medida "${measurement.label}" deve ter ate ${BODY_MEASUREMENT_RULES.maxUnitLength} caracteres.`,
+        400,
+      );
+    }
+
+    parsedMeasurements.push({
+      key,
+      label: measurement.label,
+      unit,
+      value: roundMeasurementValue(parsedValue, { key, unit }),
+    });
+    seenKeys.add(key);
+  });
+
+  return parsedMeasurements;
 }
 
 function parseMealPlanItems(items) {
@@ -337,11 +476,20 @@ class NutritionistDashboardService {
     const imc = toNumber(payload.imc, weight && height ? weight / (height * height) : 0);
     const bodyFat = toNumber(payload.bodyFat, patient.bodyFat);
     const notes = String(payload.notes || '').trim() || 'Avaliacao registrada.';
+    const extraMeasurements = parseAdditionalMeasurements(payload.measurements);
     const lastSnapshot = patient.progressSnapshots[patient.progressSnapshots.length - 1];
     const adherenceBase = lastSnapshot ? lastSnapshot.adherence : patient.progress;
     const nextAdherence = Math.min(99, Math.max(0, Math.round(adherenceBase + 3)));
     const nextProgress = Math.min(99, Math.max(patient.progress, Math.round((patient.progress + nextAdherence) / 2)));
     const snapshotLabel = `S${patient.progressSnapshots.length + 1}`;
+    const measurements = buildAssessmentMeasurements({
+      weight,
+      height,
+      bodyFat,
+      imc,
+      recordedAt: date,
+      extraMeasurements,
+    });
 
     const assessment = await this.nutritionistDashboardRepository.createAssessment({
       nutritionistId: nutritionist.id,
@@ -352,6 +500,7 @@ class NutritionistDashboardService {
       imc,
       bodyFat,
       notes,
+      measurements,
       adherence: nextAdherence,
       progress: nextProgress,
       status: nextProgress < 45 ? 'Atrasado' : 'Ativo',
@@ -483,7 +632,7 @@ class NutritionistDashboardService {
 
   async sendMessage(nutritionist, payload) {
     const patientProfileId = String(payload.patientId || '').trim();
-    const content = String(payload.content || '').trim();
+    const content = normalizeText(payload.content);
 
     if (!patientProfileId) {
       throw new AppError('Informe o paciente para enviar a mensagem.', 400);
@@ -491,6 +640,10 @@ class NutritionistDashboardService {
 
     if (!content) {
       throw new AppError('Digite uma mensagem para responder ao paciente.', 400);
+    }
+
+    if (content.length > CHAT_MESSAGE_MAX_LENGTH) {
+      throw new AppError(`A mensagem deve ter ate ${CHAT_MESSAGE_MAX_LENGTH} caracteres.`, 400);
     }
 
     const patientProfile = await this.nutritionistDashboardRepository.findPatientConversation(
@@ -716,6 +869,7 @@ class NutritionistDashboardService {
           },
         ];
     const weightTimeline = buildWeightTimeline(patientProfile);
+    const bodyMeasurements = getBodyMeasurementsTimeline(patientProfile);
 
     return {
       id: patientProfile.id,
@@ -745,6 +899,7 @@ class NutritionistDashboardService {
         date: formatShortDate(entry.recordedAt),
         note: entry.note || '',
       })),
+      bodyMeasurements: this.toBodyMeasurementsDto(bodyMeasurements),
       lastMessagePreview: latestMessage?.content || 'Sem mensagens recentes.',
       lastMessageTime: latestMessage ? formatMessageTime(latestMessage.sentAt) : '',
       pendingMessages,
@@ -797,6 +952,16 @@ class NutritionistDashboardService {
   }
 
   toAssessmentDto(assessment) {
+    const measurements = assessment.bodyMeasurements?.length
+      ? assessment.bodyMeasurements
+      : buildAssessmentMeasurements({
+          weight: assessment.weight,
+          height: assessment.height,
+          bodyFat: assessment.bodyFat,
+          imc: assessment.imc,
+          recordedAt: assessment.date,
+        });
+
     return {
       id: assessment.id,
       patientId: assessment.patientProfileId,
@@ -807,6 +972,47 @@ class NutritionistDashboardService {
       imc: assessment.imc,
       bodyFat: assessment.bodyFat,
       notes: assessment.notes,
+      measurements: this.toAssessmentMeasurementItemsDto(measurements),
+    };
+  }
+
+  toAssessmentMeasurementItemsDto(measurements) {
+    return measurements.map((measurement) => ({
+      id: measurement.id || `${measurement.key}:${measurement.recordedAt || 'assessment'}`,
+      key: measurement.key,
+      label: measurement.label,
+      unit: measurement.unit,
+      value: measurement.value,
+      valueLabel: formatMeasurementValue(measurement.value, measurement.unit, measurement.key),
+    }));
+  }
+
+  toBodyMeasurementsDto(measurements) {
+    const latestMeasurements = getLatestMeasurementsByType(measurements, 8);
+    const historyGroups = groupMeasurementsByDate(measurements, 6);
+
+    return {
+      latest: latestMeasurements.map((measurement) => ({
+        id: measurement.id,
+        key: measurement.key,
+        label: measurement.label,
+        unit: measurement.unit,
+        value: measurement.value,
+        valueLabel: formatMeasurementValue(measurement.value, measurement.unit, measurement.key),
+        dateLabel: formatShortDate(measurement.recordedAt),
+      })),
+      history: historyGroups.map((group) => ({
+        id: group.groupKey,
+        dateLabel: formatShortDate(group.recordedAt),
+        items: group.items.map((measurement) => ({
+          id: measurement.id,
+          key: measurement.key,
+          label: measurement.label,
+          unit: measurement.unit,
+          value: measurement.value,
+          valueLabel: formatMeasurementValue(measurement.value, measurement.unit, measurement.key),
+        })),
+      })),
     };
   }
 

--- a/src/services/patientDashboardService.js
+++ b/src/services/patientDashboardService.js
@@ -1,5 +1,11 @@
 const { AppError } = require('../errors/appError');
 const { isNutritionistRole } = require('../constants/roles');
+const {
+  buildAssessmentMeasurements,
+  formatMeasurementValue,
+  getLatestMeasurementsByType,
+  groupMeasurementsByDate,
+} = require('../utils/bodyMeasurements');
 
 const SHORT_MONTHS = ['Jan', 'Fev', 'Mar', 'Abr', 'Mai', 'Jun', 'Jul', 'Ago', 'Set', 'Out', 'Nov', 'Dez'];
 const ALLOWED_MEAL_TYPES = new Set([
@@ -24,6 +30,7 @@ const WEEKLY_WEIGHT_LIMITS = {
   min: 20,
   max: 350,
 };
+const CHAT_MESSAGE_MAX_LENGTH = 500;
 
 function normalizeEmail(value) {
   return String(value || '').trim().toLowerCase();
@@ -428,6 +435,51 @@ function buildWeightTimeline(patientProfile) {
   return [];
 }
 
+function buildFallbackBodyMeasurements(patientProfile) {
+  if (patientProfile.assessments?.length) {
+    return patientProfile.assessments.flatMap((assessment) => buildAssessmentMeasurements({
+      weight: assessment.weight,
+      height: assessment.height,
+      bodyFat: assessment.bodyFat,
+      imc: assessment.imc,
+      recordedAt: assessment.date,
+    }).map((measurement) => ({
+      id: `${assessment.id}:${measurement.key}`,
+      ...measurement,
+    })));
+  }
+
+  if (!patientProfile.currentWeight && !patientProfile.height && !patientProfile.bodyFat) {
+    return [];
+  }
+
+  const recordedAt = patientProfile.lastAssessmentAt || patientProfile.updatedAt || new Date();
+  const imc = patientProfile.currentWeight > 0 && patientProfile.height > 0
+    ? patientProfile.currentWeight / (patientProfile.height * patientProfile.height)
+    : 0;
+
+  return buildAssessmentMeasurements({
+    weight: patientProfile.currentWeight,
+    height: patientProfile.height,
+    bodyFat: patientProfile.bodyFat,
+    imc,
+    recordedAt,
+  })
+    .filter((measurement) => measurement.value > 0)
+    .map((measurement) => ({
+      id: `profile:${measurement.key}`,
+      ...measurement,
+    }));
+}
+
+function getBodyMeasurementsTimeline(patientProfile) {
+  if (patientProfile.bodyMeasurements?.length) {
+    return patientProfile.bodyMeasurements;
+  }
+
+  return buildFallbackBodyMeasurements(patientProfile);
+}
+
 class PatientDashboardService {
   constructor(patientDashboardRepository, userRepository) {
     this.patientDashboardRepository = patientDashboardRepository;
@@ -657,6 +709,10 @@ class PatientDashboardService {
       throw new AppError('Digite uma mensagem para enviar ao nutricionista.', 400);
     }
 
+    if (content.length > CHAT_MESSAGE_MAX_LENGTH) {
+      throw new AppError(`A mensagem deve ter ate ${CHAT_MESSAGE_MAX_LENGTH} caracteres.`, 400);
+    }
+
     const chatMessage = await this.patientDashboardRepository.createPatientMessage({
       patientProfileId: patientProfile.id,
       nutritionistId: patientProfile.nutritionistId,
@@ -742,6 +798,7 @@ class PatientDashboardService {
     const mealConsistencyTarget = 4;
     const dailySummaries = this.buildDailySummaries(patientProfile.mealEntries, calorieTarget);
     const weightTimeline = buildWeightTimeline(patientProfile);
+    const bodyMeasurements = getBodyMeasurementsTimeline(patientProfile);
     const calorieProgress = calculateTargetProgress(todayTotals.calories, calorieTarget);
     const proteinProgress = calculateTargetProgress(todayTotals.protein, proteinTarget);
     const mealProgress = calculateTargetProgress(todayMeals.length, mealConsistencyTarget);
@@ -863,6 +920,7 @@ class PatientDashboardService {
         trendLabel: this.getWeightTrendLabel(weightTimeline),
         history: this.toWeightHistoryDto(weightTimeline),
       },
+      bodyMeasurements: this.toBodyMeasurementsDto(bodyMeasurements),
       chat: this.toChatDto(patientProfile),
       clinical: {
         nextAppointment: nextAppointment
@@ -1073,6 +1131,35 @@ class PatientDashboardService {
         note: entry.note || '',
       };
     });
+  }
+
+  toBodyMeasurementsDto(measurements) {
+    const latestMeasurements = getLatestMeasurementsByType(measurements, 8);
+    const historyGroups = groupMeasurementsByDate(measurements, 6);
+
+    return {
+      latest: latestMeasurements.map((measurement) => ({
+        id: measurement.id,
+        key: measurement.key,
+        label: measurement.label,
+        unit: measurement.unit,
+        value: measurement.value,
+        valueLabel: formatMeasurementValue(measurement.value, measurement.unit, measurement.key),
+        dateLabel: formatShortDate(measurement.recordedAt),
+      })),
+      history: historyGroups.map((group) => ({
+        id: group.groupKey,
+        dateLabel: formatShortDate(group.recordedAt),
+        items: group.items.map((measurement) => ({
+          id: measurement.id,
+          key: measurement.key,
+          label: measurement.label,
+          unit: measurement.unit,
+          value: measurement.value,
+          valueLabel: formatMeasurementValue(measurement.value, measurement.unit, measurement.key),
+        })),
+      })),
+    };
   }
 
   toMealEntryDto(mealEntry) {

--- a/src/utils/bodyMeasurements.js
+++ b/src/utils/bodyMeasurements.js
@@ -1,0 +1,192 @@
+const CORE_BODY_MEASUREMENT_DEFINITIONS = [
+  { key: 'weight', label: 'Peso', unit: 'kg', sourceKey: 'weight', decimals: 1 },
+  { key: 'height', label: 'Altura', unit: 'm', sourceKey: 'height', decimals: 2 },
+  { key: 'body-fat', label: 'Gordura corporal', unit: '%', sourceKey: 'bodyFat', decimals: 1 },
+  { key: 'imc', label: 'IMC', unit: '', sourceKey: 'imc', decimals: 1 },
+];
+
+const CORE_BODY_MEASUREMENT_KEYS = new Set(
+  CORE_BODY_MEASUREMENT_DEFINITIONS.map((definition) => definition.key),
+);
+
+function normalizeMeasurementKey(value) {
+  return String(value || '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 48);
+}
+
+function getMeasurementFractionDigits(unit = '', key = '') {
+  if (key === 'height' || String(unit || '').trim().toLowerCase() === 'm') {
+    return 2;
+  }
+
+  return 1;
+}
+
+function roundMeasurementValue(value, options = {}) {
+  const parsed = Number(value);
+
+  if (!Number.isFinite(parsed)) {
+    return 0;
+  }
+
+  const fractionDigits = getMeasurementFractionDigits(options.unit, options.key);
+  return Number(parsed.toFixed(fractionDigits));
+}
+
+function formatMeasurementValue(value, unit = '', key = '') {
+  const parsed = Number(value);
+
+  if (!Number.isFinite(parsed)) {
+    return '--';
+  }
+
+  const fractionDigits = getMeasurementFractionDigits(unit, key);
+  const formatted = parsed.toLocaleString('pt-BR', {
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
+  });
+
+  if (!unit) {
+    return formatted;
+  }
+
+  const trimmedUnit = String(unit).trim();
+  return trimmedUnit === '%'
+    ? `${formatted}${trimmedUnit}`
+    : `${formatted} ${trimmedUnit}`;
+}
+
+function getMeasurementPriority(key = '') {
+  const normalizedKey = String(key || '').trim();
+  const index = CORE_BODY_MEASUREMENT_DEFINITIONS.findIndex(
+    (definition) => definition.key === normalizedKey,
+  );
+
+  return index === -1 ? CORE_BODY_MEASUREMENT_DEFINITIONS.length + 10 : index;
+}
+
+function compareMeasurementEntries(left, right) {
+  const priorityDifference = getMeasurementPriority(left?.key) - getMeasurementPriority(right?.key);
+
+  if (priorityDifference !== 0) {
+    return priorityDifference;
+  }
+
+  return String(left?.label || '').localeCompare(String(right?.label || ''), 'pt-BR');
+}
+
+function sortMeasurementsByRecency(measurements = []) {
+  return [...measurements].sort((left, right) => {
+    const timeDifference = new Date(right.recordedAt).getTime() - new Date(left.recordedAt).getTime();
+
+    if (timeDifference !== 0) {
+      return timeDifference;
+    }
+
+    return compareMeasurementEntries(left, right);
+  });
+}
+
+function getLatestMeasurementsByType(measurements = [], limit = 6) {
+  const latestByKey = new Map();
+
+  for (const measurement of sortMeasurementsByRecency(measurements)) {
+    if (latestByKey.has(measurement.key)) {
+      continue;
+    }
+
+    latestByKey.set(measurement.key, measurement);
+
+    if (latestByKey.size >= limit) {
+      break;
+    }
+  }
+
+  return [...latestByKey.values()].sort(compareMeasurementEntries);
+}
+
+function groupMeasurementsByDate(measurements = [], limit = 6) {
+  const groups = [];
+  const groupsByKey = new Map();
+
+  for (const measurement of sortMeasurementsByRecency(measurements)) {
+    const recordedAt = new Date(measurement.recordedAt);
+
+    if (Number.isNaN(recordedAt.getTime())) {
+      continue;
+    }
+
+    const groupKey = recordedAt.toISOString().slice(0, 10);
+
+    if (!groupsByKey.has(groupKey)) {
+      if (groups.length >= limit) {
+        continue;
+      }
+
+      const group = {
+        groupKey,
+        recordedAt,
+        items: [],
+      };
+
+      groupsByKey.set(groupKey, group);
+      groups.push(group);
+    }
+
+    groupsByKey.get(groupKey).items.push(measurement);
+  }
+
+  return groups.map((group) => ({
+    ...group,
+    items: [...group.items].sort(compareMeasurementEntries),
+  }));
+}
+
+function buildAssessmentMeasurements(payload) {
+  const {
+    weight,
+    height,
+    bodyFat,
+    imc,
+    recordedAt,
+    extraMeasurements = [],
+  } = payload;
+
+  const coreMeasurements = CORE_BODY_MEASUREMENT_DEFINITIONS.map((definition) => ({
+    key: definition.key,
+    label: definition.label,
+    unit: definition.unit,
+    value: roundMeasurementValue(payload[definition.sourceKey], definition),
+    recordedAt,
+  }));
+
+  const customMeasurements = extraMeasurements.map((measurement) => ({
+    key: measurement.key,
+    label: measurement.label,
+    unit: measurement.unit,
+    value: roundMeasurementValue(measurement.value, measurement),
+    recordedAt,
+  }));
+
+  return [
+    ...coreMeasurements,
+    ...customMeasurements,
+  ];
+}
+
+module.exports = {
+  CORE_BODY_MEASUREMENT_DEFINITIONS,
+  CORE_BODY_MEASUREMENT_KEYS,
+  buildAssessmentMeasurements,
+  compareMeasurementEntries,
+  formatMeasurementValue,
+  getLatestMeasurementsByType,
+  groupMeasurementsByDate,
+  normalizeMeasurementKey,
+  roundMeasurementValue,
+};


### PR DESCRIPTION
## Resumo
- adiciona suporte a medidas corporais flexiveis com historico por avaliacao
- exibe medidas corporais na tela do paciente e no painel do nutricionista
- corrige o chat do nutricionista com carregamento da conversa, envio de mensagens e atualizacao automatica
- adiciona validacao de tamanho maximo para mensagens do chat

## Commits
- `adiciona medidas corporais`
- `corrige chat do nutricionista`

## Validacao
- `npm run db:push`
- `npm run prisma:generate`
- `node --check frontend/dashboard-nutricionista.js`
- `node --check src/services/nutritionistDashboardService.js`
- `node --check src/services/patientDashboardService.js`
- smoke test das rotas `GET /api/nutritionist/conversation` e `POST /api/nutritionist/messages`
- validacao de erro para mensagens com mais de 500 caracteres no paciente e no nutricionista